### PR TITLE
fix: protect access to currentStep in measurements

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -193,7 +193,7 @@ export class Modal extends React.Component<ModalProps, State> {
         : obj.top -
         MARGIN -
         135 -
-        (this.props.currentStep!.tooltipBottomOffset || 0)
+        (this.props.currentStep?.tooltipBottomOffset || 0)
     const translateAnim = Animated.timing(this.state.tooltipTranslateY, {
       toValue,
       duration,


### PR DESCRIPTION
When the tour was ended, another measuring happened that caused an unhandled Rejection.

```
Possible Unhandled Promise Rejection (id: 0):
TypeError: undefined is not an object (evaluating 'this.props.currentStep.tooltipBottomOffset')
```